### PR TITLE
Refactor(visibility) jd update visibility handling

### DIFF
--- a/src/3d/camera/camera.js
+++ b/src/3d/camera/camera.js
@@ -2,7 +2,7 @@
  * @file A simple camera state object.
  *
  * @author noodep
- * @version 0.95
+ * @version 0.96
  */
 
 import Vec3 from '../../math/vec3.js';
@@ -61,12 +61,20 @@ export default class Camera {
 		this.updateView();
 	}
 
+	get position() {
+		return this._position.clone();
+	}
+
 	/**
 	 * Sets this camera orientation and immediately updates the view.
 	 */
 	set orientation(orientation) {
 		this._orientation.copy(orientation);
 		this.updateView();
+	}
+
+	get orientation() {
+		return this._orientation.clone();
 	}
 
 	/**
@@ -109,7 +117,7 @@ export default class Camera {
 	}
 
 	/**
-	 * Sets this camera position and drientation and immediately updates the view.
+	 * Sets this camera position and orientation and immediately updates the view.
 	 */
 	setPose(position, orientation) {
 		this._position.copy(position);

--- a/src/3d/camera/camera.js
+++ b/src/3d/camera/camera.js
@@ -117,13 +117,21 @@ export default class Camera {
 	}
 
 	/**
-	 * Sets this camera position and orientation and immediately updates the view.
+	 * Sets this camera position and orientation and immediately updates the view with verbose logging.
 	 */
 	setPose(position, orientation) {
+		console.log(`Setting camera pose. New position: (${position.toString()}), New orientation: (${orientation.toString()})`);
+
 		this._position.copy(position);
+		console.log(`Camera position updated to: (${this._position.toString()})`);
+
 		this._orientation.copy(orientation);
+		console.log(`Camera orientation updated to: (${this._orientation.toString()})`);
+
 		this.updateView();
+		console.log(`Camera view updated.`);
 	}
+
 
 	/**
 	 * Sets this camera clipping planes and immediately updates the projection.

--- a/src/3d/camera/camera.js
+++ b/src/3d/camera/camera.js
@@ -117,21 +117,13 @@ export default class Camera {
 	}
 
 	/**
-	 * Sets this camera position and orientation and immediately updates the view with verbose logging.
+	 * Sets this camera position and orientation and immediately updates the view.
 	 */
 	setPose(position, orientation) {
-		console.log(`Setting camera pose. New position: (${position.toString()}), New orientation: (${orientation.toString()})`);
-
 		this._position.copy(position);
-		console.log(`Camera position updated to: (${this._position.toString()})`);
-
 		this._orientation.copy(orientation);
-		console.log(`Camera orientation updated to: (${this._orientation.toString()})`);
-
 		this.updateView();
-		console.log(`Camera view updated.`);
 	}
-
 
 	/**
 	 * Sets this camera clipping planes and immediately updates the projection.

--- a/src/3d/control/orbit.js
+++ b/src/3d/control/orbit.js
@@ -2,7 +2,8 @@
  * @file object manipulation through orbit control
  *
  * @author noodep
- * @version 2.28
+ * @author jdiemert
+ * @version 2.34
  */
 
 import Quat from '../../math/quat.js';
@@ -134,8 +135,8 @@ export default class OrbitControl extends EventTarget {
 		let forward = new Vec3(0, 0, 1);
 		forward = orientation.rotate(forward);
 		// 2. Compute azimuth and inclination from forward vector
-		result.x = Math.atan2(forward._v[1], forward._v[0]); // azimuth
-		result.y = Math.acos(forward._v[2] / forward.magnitude()); // inclination
+		result.x = Math.atan2(forward.y, forward.x); // azimuth
+		result.y = Math.acos(forward.z / forward.magnitude()); // inclination
 		result.y += OrbitControl.HALF_PI; // add PI/2 since it was subtracted during the original calculation
 
 		return result;
@@ -239,6 +240,17 @@ export default class OrbitControl extends EventTarget {
 	}
 
 	/**
+	 * Ensures consistent representation of the quaternion for azimuth and inclination calculations.
+	 * Normalizes the quaternion and adjusts its representation if necessary.
+	 * @param {Quat} quaternion - The quaternion to adjust.
+	 * @return {Quat} - The adjusted quaternion.
+	 */
+	static adjustQuaternion(quaternion) {
+		let adjustedQuaternion = quaternion.clone().normalize();
+		return adjustedQuaternion;
+	}
+
+	/**
 	 * Sets the state of the OrbitControl from the given target's state.
 	 * It first calculates the spherical coordinates from the target's position.
 	 * Then, it determines the azimuth and inclination from the target's orientation.
@@ -247,22 +259,19 @@ export default class OrbitControl extends EventTarget {
 	 * @param {Object3D} target - The target object from which to set the state.
 	 */
 	setFromTarget(target) {
-		// Calculate the spherical coordinates from the target's position
+		// Adjust the target's orientation quaternion before calculations
+		let adjustedOrientation = OrbitControl.adjustQuaternion(target.orientation);
+		// Proceed with calculations using the adjusted orientation
 		const sphericalCoordinates = OrbitControl.cartesianToSpherical(this._offset, target.position);
 
 		this._radius = sphericalCoordinates.x;
 		this._azimuth = sphericalCoordinates.y;
 		this._inclination = sphericalCoordinates.z;
 
-		// Calculate the azimuth and inclination from the target's orientation
-		const azimuthInclination = OrbitControl.quaternionToAzimuthInclination(target.orientation);
+		const azimuthInclination = OrbitControl.quaternionToAzimuthInclination(adjustedOrientation);
 
-		// We need to make sure that the azimuth and inclination are within the correct ranges
-		this._azimuth = (azimuthInclination.x + OrbitControl.TWO_PI) % OrbitControl.TWO_PI;
-		this._inclination = Math.max(Math.min(azimuthInclination.y, Math.PI), 0);
 
-		// Call update position to make sure everything is synced
-		this._updatePosition();
+		this._updatePosition({set_pose: false});
 	}
 
 	/**
@@ -284,11 +293,15 @@ export default class OrbitControl extends EventTarget {
 	 * It first calculates the new position using the current state, then determines the orientation.
 	 * Finally, it sets the new pose for the target.
 	 */
-	_updatePosition() {
+	// need to pass in optional set_pose parameter to avoid infinite loop when calling this function from setFromTarget, and default for this method when this parameter is not being passed in is true
+	_updatePosition({set_pose = true} = {}) {
 		OrbitControl.position(this._offset, this._radius, this._azimuth, this._inclination, this._position);
 		OrbitControl.orientation(this._azimuth, this._inclination, this._orientation, this._inclination_orientation);
-
-		this._target.setPose(this._position, this._orientation);
+		// console to log the position and orientation of the orbit control and where the console log is coming from
+		console.log("OrbitControl.js: ", this._position.toString(), this._orientation.toString());
+		if (set_pose) {
+			this._target.setPose(this._position, this._orientation);
+		}
 	}
 
 }

--- a/src/3d/control/orbit.js
+++ b/src/3d/control/orbit.js
@@ -268,9 +268,10 @@ export default class OrbitControl extends EventTarget {
 		this._azimuth = sphericalCoordinates.y;
 		this._inclination = sphericalCoordinates.z;
 
+		// Calculate the azimuth and inclination from the target's orientation
 		const azimuthInclination = OrbitControl.quaternionToAzimuthInclination(adjustedOrientation);
 
-
+		// Set the OrbitControl's azimuth and inclination to the calculated values, no need to update the target's pose
 		this._updatePosition({set_pose: false});
 	}
 
@@ -293,12 +294,11 @@ export default class OrbitControl extends EventTarget {
 	 * It first calculates the new position using the current state, then determines the orientation.
 	 * Finally, it sets the new pose for the target.
 	 */
-	// need to pass in optional set_pose parameter to avoid infinite loop when calling this function from setFromTarget, and default for this method when this parameter is not being passed in is true
+	// need to pass in optional set_pose parameter to avoid infinite loop when calling this function from setFromTarget
 	_updatePosition({set_pose = true} = {}) {
 		OrbitControl.position(this._offset, this._radius, this._azimuth, this._inclination, this._position);
 		OrbitControl.orientation(this._azimuth, this._inclination, this._orientation, this._inclination_orientation);
-		// console to log the position and orientation of the orbit control and where the console log is coming from
-		console.log("OrbitControl.js: ", this._position.toString(), this._orientation.toString());
+
 		if (set_pose) {
 			this._target.setPose(this._position, this._orientation);
 		}

--- a/src/3d/control/simple-orbit-control-input.js
+++ b/src/3d/control/simple-orbit-control-input.js
@@ -80,9 +80,9 @@ export default class SimpleOrbitControlInput {
 		const delta = this.#sensitivityAdjustedDisplacement(e, Math.sign(e.deltaY) * this.#wheel_sensitivity);
 
 		if(e.shiftKey)
-			this.#orbit_control.radius += delta;
-		else
 			this.#camera.verticalFieldOfView = this.#camera.verticalFieldOfView + delta;
+		else
+			this.#orbit_control.radius += delta;
 	}
 
 	/**

--- a/src/3d/control/simple-orbit-control-input.js
+++ b/src/3d/control/simple-orbit-control-input.js
@@ -39,7 +39,7 @@ export default class SimpleOrbitControlInput {
 	#attachEvents() {
 		this.#$element.addEventListener('contextmenu', e => e.preventDefault());
 		this.#$element.addEventListener('mousedown', this.#handleMouseDown.bind(this));
-		this.#$element.addEventListener('mouseup', this.#handleMouseUp.bind(this));
+		window.addEventListener('mouseup', this.#handleMouseUp.bind(this));
 		this.#$element.addEventListener('wheel', this.#handleMouseWheel.bind(this));
 	}
 
@@ -47,14 +47,14 @@ export default class SimpleOrbitControlInput {
 	 * Handles mouse down events.
 	 */
 	#handleMouseDown() {
-		this.#$element.addEventListener('mousemove', this.#mouseMoveHandler);
+		window.addEventListener('mousemove', this.#mouseMoveHandler);
 	}
 
 	/**
 	 * Handles mouse up events.
 	 */
 	#handleMouseUp() {
-		this.#$element.removeEventListener('mousemove', this.#mouseMoveHandler);
+		window.removeEventListener('mousemove', this.#mouseMoveHandler);
 	}
 
 	/**

--- a/src/3d/geometry/plane.js
+++ b/src/3d/geometry/plane.js
@@ -15,10 +15,10 @@ export default class Plane {
 	static generatePlaneVertices(origin = new Vec3(), scale = Vec3.identity()) {
 		const i = 0.5;
 		return [
-			[origin.x - i * scale.x, origin.y, origin.z - i * scale.z],
-			[origin.x + i * scale.x, origin.y, origin.z - i * scale.z],
-			[origin.x + i * scale.x, origin.y, origin.z + i * scale.z],
-			[origin.x - i * scale.x, origin.y, origin.z + i * scale.z],
+			[origin.x - i * scale.x, origin.y - i * scale.y, origin.z],
+			[origin.x + i * scale.x, origin.y - i * scale.y, origin.z],
+			[origin.x + i * scale.x, origin.y + i * scale.y, origin.z],
+			[origin.x - i * scale.x, origin.y + i * scale.y, origin.z]
 		];
 	}
 

--- a/src/3d/object3d.js
+++ b/src/3d/object3d.js
@@ -181,8 +181,6 @@ export default class Object3D extends Listenable {
 
 	/**
 	 * Setter for this Object3d visibility.
-	 * This method now also ensures that changing the visibility of a parent
-	 * object will recursively update the visibility of all its child objects.
 	 *
 	 * @param {Boolean} value - This Object3d new visibility state.
 	 */

--- a/src/3d/object3d.js
+++ b/src/3d/object3d.js
@@ -50,6 +50,7 @@ export default class Object3D extends Listenable {
 		this._origin = Vec3.from(origin);
 		this._orientation = Quat.from(orientation);
 		this._scale = Vec3.from(scale);
+		this._visible = true;
 		this._is_model_valid = false;
 		this._local_model = Mat4.identity();
 		this._world_model = Mat4.identity();
@@ -171,6 +172,23 @@ export default class Object3D extends Listenable {
 		this._scale.copy(v3);
 		this._invalidateModel();
 		this.notify('size', this._scale);
+	}
+
+	// Visibility getter
+	get visible() {
+		return this._visible;
+	}
+
+	/**
+	 * Setter for this Object3d visibility.
+	 * This method now also ensures that changing the visibility of a parent
+	 * object will recursively update the visibility of all its child objects.
+	 *
+	 * @param {Boolean} value - This Object3d new visibility state.
+	 */
+	set visible(value) {
+		this._visible = value;
+		this.notify('visibility', this._visible);
 	}
 
 	/**

--- a/src/3d/object3d.js
+++ b/src/3d/object3d.js
@@ -416,14 +416,14 @@ export default class Object3D extends Listenable {
 			this.parent.removeChild(this);
 		}
 
-		this.clearListeners();
-
 		for (let child of this._children) {
 			this.removeChild(child);
 			child.destroy();
 		}
 
 		this.notify('destroy');
+
+		this.clearListeners();
 	}
 
 	/**

--- a/src/3d/object3d.js
+++ b/src/3d/object3d.js
@@ -2,7 +2,7 @@
  * @file Object3d class that represent a object that can be manipulated in a 3d environment
  *
  * @author noodep
- * @version 0.99
+ * @version 1.01
  */
 
 import { uuidv4 } from '../crypto/uuid.js';
@@ -13,20 +13,31 @@ import Listenable from '../util/listenable.js';
 import { wl } from '../util/log.js';
 
 /**
- * Object in a 3D environment.
+ * @typedef {import('../math/vec3.js').default} Vec3
+ * @typedef {import('../math/quat.js').default} Quat
  *
- * Fires the following event types:
- * property:
- *	'origin' - When the origin property updates; passes the new origin
- *	'orientation' - When the orientation property updates; passed the new orientation
- *	'size' - When the size proprty updates; passes the new size
- *	'model' - When the world model updates; passes the new matrix
- *	'add' - When a child is added; passes this object and the added one
- *	'remove' - When a child is removed; passes this object and the removed one
- *	'destroy' - Directly after destroy() has been called
- *	'visibility' - When the visibility property updates; passes the new visibility state
- * Note that "updates" above does not necessarily imply "changes"
- * Events will be fired when the property has the possibility of changing.
+ * @typedef {[number,number,number]} Vec3Tuple
+ * @typedef {[number,number,number,number]} QuatTuple
+ * @typedef {Vec3|Vec3Tuple} VecLike
+ * @typedef {Quat|QuatTuple} QuatLike
+ */
+
+/**
+ * @typedef {{ x:number, y:number, z:number }} OriginEvent
+ * @typedef {{ x:number, y:number, z:number, w:number }} OrientationEvent
+ * @typedef {{ x:number, y:number, z:number }} ScaleEvent
+ * @typedef {{ m:number[] }} ModelEvent
+ */
+
+/**
+ * Object in a 3D environment.
+ * @fires 'origin' {OriginEvent}
+ * @fires 'orientation' {OrientationEvent}
+ * @fires 'size' {ScaleEvent}
+ * @fires 'model' {ModelEvent}
+ * @fires 'add' {{ parent:Object3D, child:Object3D }}
+ * @fires 'remove' {{ parent:Object3D, child:Object3D }}
+ * @fires 'destroy' {{}}
  */
 export default class Object3D extends Listenable {
 
@@ -37,28 +48,24 @@ export default class Object3D extends Listenable {
 	 *
 	 * @param {String} [id=uuidv4()] - this object's id.
 	 * @param {String} [name=''] - this object's name.
-	 * @param {Array} [origin] - a 3 dimensional array containing this object origin.
-	 * @param {Array} [orientation] - a 3 dimensional array containing this object orientation. Euler angles in radians around XYZ.
-	 * @param {Array} [scale] - a 3 dimensional array containing this object scaling.
+	 * @param {VecLike} [origin=Vec3.NULL] - a 3 dimensional array containing this object origin or a Vec3.
+	 * @param {QuatLike} [orientation=Quat.IDENTITY] - a 3 dimensional array containing this object orientation. Euler angles in radians around XYZ or a Quat.
+	 * @param {VecLike} [scale=Vec3.IDENTITY] - a 3 dimensional array containing this object scaling or a Vec3.
 	 * @return {module:3d.Object3d} - The newly created Object3d.
 	 */
 	constructor(id = uuidv4(), name = '', origin = Vec3.NULL, orientation = Quat.IDENTITY, scale = Vec3.IDENTITY) {
 		super();
-		this._id = id;
-		this._name = name;
-		this._parent = undefined;
-		this._children = new Set();
-		this._origin = Vec3.from(origin);
-		this._orientation = Quat.from(orientation);
-		this._scale = Vec3.from(scale);
-		this._visible = true;
-		this._is_model_valid = false;
-		this._local_model = Mat4.identity();
-		this._world_model = Mat4.identity();
-		this._listen_to_parent_visibility = true;
-
-		// Temporary quaternion used for rotations. This avoids creating one each time.
-		this._tmp_quaternion = new Quat();
+        /** @type {string} */ this._id = id;
+        /** @type {string} */ this._name = name;
+		/** @type {Object3D|undefined} */ this._parent = undefined;
+		/** @type {Set<Object3D>} */ this._children = new Set();
+		/** @type {Vec3} */ this._origin = Vec3.from(origin);
+		/** @type {Quat} */ this._orientation = Quat.from(orientation);
+		/** @type {Vec3} */ this._scale = Vec3.from(scale);
+		/** @type {Boolean} */ this._is_model_valid = false;
+		/** @type {Mat4} */ this._local_model = Mat4.identity();
+		/** @type {Mat4} */ this._world_model = Mat4.identity();
+		/** @type {Quat} */ this._tmp_quaternion = new Quat(); 	// Temporary quaternion used for rotations. This avoids creating one each time.
 	}
 
 	/**
@@ -176,21 +183,6 @@ export default class Object3D extends Listenable {
 		this.notify('size', this._scale);
 	}
 
-	// Visibility getter
-	get visible() {
-		return this._visible;
-	}
-
-	/**
-	 * Setter for this Object3d visibility.
-	 *
-	 * @param {Boolean} value - This Object3d new visibility state.
-	 */
-	set visible(value) {
-		this._visible = value;
-		this.notify('visibility', this._visible);
-	}
-
 	/**
 	 * Getter for this Object3d local model matrix.
 	 *
@@ -207,10 +199,6 @@ export default class Object3D extends Listenable {
 	 */
 	get worldModel() {
 		return this._world_model;
-	}
-
-	get listenToParentVisibility() {
-		return this._listen_to_parent_visibility;
 	}
 
 	/**
@@ -231,14 +219,6 @@ export default class Object3D extends Listenable {
 		object.parent = this;
 
 		this.notify('add', this, object);
-
-		if(object.listenToParentVisibility) {
-			// Listen to this parent's visibility changes and apply them to the child
-			this.addListener('visibility', (visible) => {
-			object.visible = visible;
-			});
-			object.visible = this.visible;
-		}
 	}
 
 	/**
@@ -254,6 +234,8 @@ export default class Object3D extends Listenable {
 
 	/**
 	 * Returns an iterator over the children of this Object3D.
+	 *
+	 * @return {Iterator} - An iterator over the children of this Object3D.
 	 */
 	getChildren() {
 		return this._children.values();
@@ -272,11 +254,6 @@ export default class Object3D extends Listenable {
 			return false;
 		}
 
-		if(object.listenToParentVisibility) {
-			// Remove the listener that applies this parent's visibility to the child
-			this.removeListener('visibility');
-		}
-
 		this._children.delete(object);
 		object.parent = undefined;
 		this.notify('remove', this, object);
@@ -285,11 +262,15 @@ export default class Object3D extends Listenable {
 
 	/**
 	 * Removes all children from this Object3D.
+	 *
+	 * @return {Boolean} - true if any child was removed, false otherwise.
 	 */
 	clearChildren() {
+		let removed = false;
 		for (let child of this._children) {
-			this.removeChild(child);
+			removed |= this.removeChild(child);
 		}
+		return removed;
 	}
 
 	/**

--- a/src/3d/scene.js
+++ b/src/3d/scene.js
@@ -167,13 +167,18 @@ export default class Scene extends Object3D {
 	}
 
 	/**
-	 * Render this Scene using program batches.
+	 * Render this Scene using program batches, respecting the visibility of renderables.
 	 */
 	render(renderer) {
 		this._program_cache.forEach((renderables, program_name) => {
 			this.applyProgramState(renderer, program_name);
 
-			for(let renderable of renderables) {
+			for (let renderable of renderables) {
+				// Check if the renderable is visible before rendering
+				if (!renderable.visible) {
+					continue; // Skip rendering this renderable if it's not visible
+				}
+
 				renderable.setShaderState(renderer);
 				renderable.render(renderer);
 				renderable.cleanShaderState(renderer);

--- a/src/3d/scene.js
+++ b/src/3d/scene.js
@@ -3,11 +3,12 @@
  *
  * @author noodep
  * @author jdiemert
- * @version 0.25
+ * @version 0.26
  */
 
 import Renderable from '../gl/renderable.js';
 import Object3D from './object3d.js';
+import { wl } from '../util/log.js';
 
 /**
  * Scene to render a hierarchy of Renderables.
@@ -250,7 +251,11 @@ export default class Scene extends Object3D {
 		const removed = this._removeRenderableFromProgramCache(renderable);
 		this._addRenderableToHiddenCache(renderable);
 		// Notify the renderable (compat listeners) that its visibility changed.
-		try { renderable.notify('visibility', false); } catch (e) { /* ignore */ }
+		try { 
+			renderable.notify('visibility', false); 
+		} catch (e) { 
+			wl(`Failed to notify renderable of visibility change: ${e.message} (renderable: ${renderable.id || renderable.constructor.name})`); 
+		}
 		return removed;
 	}
 
@@ -273,7 +278,11 @@ export default class Scene extends Object3D {
 
 		this._addRenderableToProgramCache(renderable);
 		// Notify the renderable (compat listeners) that its visibility changed.
-		try { renderable.notify('visibility', true); } catch (e) { /* ignore */ }
+		try { 
+			renderable.notify('visibility', true); 
+		} catch (e) { 
+			wl(`Failed to notify renderable of visibility change: ${e.message} (renderable: ${renderable.id || renderable.constructor.name})`); 
+		}
 		return true;
 	}
 

--- a/src/3d/scene.js
+++ b/src/3d/scene.js
@@ -2,7 +2,8 @@
  * @file Scene
  *
  * @author noodep
- * @version 0.24
+ * @author jdiemert
+ * @version 0.25
  */
 
 import Renderable from '../gl/renderable.js';
@@ -33,7 +34,18 @@ export default class Scene extends Object3D {
 		this._active_camera = 0;
 		// Tempend
 
+		/**
+		 * @type {Map<string, Set<Renderable>>}
+		 * Program → Set of renderables to be drawn.
+		 */
 		this._program_cache = new Map();
+
+		/**
+		 * @type {Map<string, Set<Renderable>>}
+		 * Program → Set of renderables that are currently hidden (not drawn).
+		 * These remain initialized and can be restored to the program cache.
+		 */
+		this._hidden_program_cache = new Map();
 
 		// Private instance symbols used to store the bound 'add' and 'remove'
 		// event handlers on each parent object so that the listeners can be
@@ -43,8 +55,8 @@ export default class Scene extends Object3D {
 	}
 
 	/**
-	 * Returns an array of all renderable objects in this scene, in no
-	 * particular order.
+	 * Returns an array of all visible (drawn) renderables in this scene, in no particular order.
+	 * @returns {Renderable[]}
 	 */
 	getRenderables() {
 		const renderables = [];
@@ -53,16 +65,42 @@ export default class Scene extends Object3D {
 				renderables.push(renderable);
 			}
 		}
-
 		return renderables;
 	}
 
+	/**
+	 * Returns an array of all hidden (not drawn) renderables retained by the scene.
+	 * @returns {Renderable[]}
+	 */
+	getHiddenRenderables() {
+		const renderables = [];
+		for (let cache of this._hidden_program_cache.values()) {
+			for (let renderable of cache) {
+				renderables.push(renderable);
+			}
+		}
+		return renderables;
+	}
+
+	/**
+	 * Returns an array of all renderables known to the scene (visible + hidden).
+	 * @returns {Renderable[]}
+	 */
+	getAllRenderables() {
+		return [...this.getRenderables(), ...this.getHiddenRenderables()];
+	}
+
+	/**
+	 * Called by renderer when this scene is attached.
+	 * @param {object} renderer
+	 */
 	sceneAttached(renderer) {
 		this.initializeObject3D(renderer, this);
 	}
 
 	/**
-	 * Adds a camera projection matrix
+	 * Adds a camera projection matrix.
+	 * @param {object} camera
 	 */
 	addCamera(camera) {
 		this._cameras.push(camera);
@@ -70,11 +108,13 @@ export default class Scene extends Object3D {
 
 	/**
 	 * Recursive initialization of the specified Object3D.
+	 * @param {object} renderer
+	 * @param {Object3D} object
 	 */
 	initializeObject3D(renderer, object) {
-		if(object instanceof Renderable) {
+		if (object instanceof Renderable) {
 			object.initialize(renderer);
-			this.addRenderableToProgramCache(object);
+			this._addRenderableToProgramCache(object);
 		}
 
 		// Utilize (exploit) the fact that a renderer is passed to this function
@@ -97,7 +137,7 @@ export default class Scene extends Object3D {
 		object[this._add_handler_symbol] = add_event_handler;
 		object[this._remove_handler_symbol] = remove_event_handler;
 
-		for(let child_object of object.getChildren()) {
+		for (let child_object of object.getChildren()) {
 			this.initializeObject3D(renderer, child_object);
 		}
 	}
@@ -107,14 +147,14 @@ export default class Scene extends Object3D {
 	 * This undoes the action of initializeObject3D() by recursively removing
 	 * event listeners on Object3D instances and removing Renderables in the
 	 * hierarchy at and below the specified object from the program cache.
+	 * Removes any renderables from both the visible and hidden caches.
 	 *
-	 * TODO Should renderables be destroyed via Renderable#destroy() when
-	 * uninitialized, or still be allowed to exist in case they are later
-	 * re-added (current behavior) ?
+	 * @param {Object3D} object
 	 */
 	uninitializeObject3D(object) {
 		if (object instanceof Renderable) {
-			this.removeRenderableFromProgramCache(object);
+			this._removeRenderableFromProgramCache(object);
+			this._removeRenderableFromHiddenCache(object);
 		}
 
 		object.removeListener('add', object[this._add_handler_symbol]);
@@ -128,46 +168,17 @@ export default class Scene extends Object3D {
 	}
 
 	/**
-	 * Add the specified {@code Renderable} to this {@code Scene} program cache.
-	 */
-	addRenderableToProgramCache(renderable) {
-		const program_name = renderable.program;
-		if(!this._program_cache.has(program_name))
-			this._program_cache.set(program_name, new Set());
-
-		this._program_cache.get(program_name).add(renderable);
-	}
-
-	/**
-	 * Remove the specified {@code Renderable} from this {@code Scene} program
-	 * cache.
-	 */
-	removeRenderableFromProgramCache(renderable) {
-		const program_name = renderable.program;
-		if (this._program_cache.has(program_name)) {
-			let cache = this._program_cache.get(program_name);
-			cache.delete(renderable);
-
-			// Remove the program altogether if there are no more renderables in
-			// it.
-			if (cache.size === 0) {
-				this._program_cache.delete(program_name);
-			}
-		}
-	}
-
-	/**
 	 * Update this Scene.
+	 * @param {number} delta_t - Time since last update in seconds.
 	 */
 	update(delta_t) {
 		this.notify('update', delta_t);
-
-		// Update Models
 		super.update(delta_t);
 	}
 
 	/**
-	 * Render this Scene using program batches, respecting the visibility of renderables.
+	 * Render this Scene using program batches.
+	 * @param {object} renderer
 	 */
 	render(renderer) {
 		// render fully opaque objects first, deferring those that may blend colors
@@ -177,15 +188,10 @@ export default class Scene extends Object3D {
 
 			let any_may_blend = false;
 			for (let renderable of renderables) {
-				// Check if the renderable is visible before rendering
-				if (!renderable.visible) {
-					continue; // Skip rendering this renderable if it's not visible
-				}
 				if (renderable.may_blend) {
 					any_may_blend = true;
 					continue;
 				}
-
 				renderable.setShaderState(renderer);
 				renderable.render(renderer);
 				renderable.cleanShaderState(renderer);
@@ -199,10 +205,6 @@ export default class Scene extends Object3D {
 				this.applyProgramState(renderer, program_name);
 
 				for (let renderable of renderables) {
-					// Check if the renderable is visible before rendering
-					if (!renderable.visible) {
-						continue; // Skip rendering this renderable if it's not visible
-					}
 					if (!renderable.may_blend) continue;
 
 					renderable.setShaderState(renderer);
@@ -218,6 +220,8 @@ export default class Scene extends Object3D {
 	/**
 	 * Applies the specified program rendering state to the specified renderer.
 	 * Camera and View for now. Fog and Overrides later.
+	 * @param {object} renderer
+	 * @param {string} program_name
 	 */
 	applyProgramState(renderer, program_name) {
 		renderer.useProgram(program_name);
@@ -225,6 +229,177 @@ export default class Scene extends Object3D {
 		const camera = this._cameras[this._active_camera];
 
 		program.applyState(renderer, camera.projection, camera.view);
+	}
+
+	/**
+	 * Hide a renderable by moving it from the visible program cache
+	 * to the hidden cache. No GPU teardown is performed; the object
+	 * remains initialized and can be restored quickly.
+	 *
+	 * @param {Renderable|string} renderable_or_id - The renderable instance or its id.
+	 * @returns {boolean} - True if a renderable was moved; false otherwise.
+	 */
+	makeRenderableInvisible(renderable_or_id) {
+		const renderable = this._resolveRenderable(renderable_or_id);
+		if (!renderable) return false;
+
+		// If it's already hidden, do nothing.
+		if (this._isInHiddenCache(renderable)) return true;
+
+		// Remove from visible cache (if present) and stash to hidden.
+		const removed = this._removeRenderableFromProgramCache(renderable);
+		this._addRenderableToHiddenCache(renderable);
+		// Notify the renderable (compat listeners) that its visibility changed.
+		try { renderable.notify('visibility', false); } catch (e) { /* ignore */ }
+		return removed;
+	}
+
+	/**
+	 * Show a previously hidden renderable by moving it from the hidden cache
+	 * back to the visible program cache.
+	 *
+	 * @param {Renderable|string} renderable_or_id - The renderable instance or its id.
+	 * @returns {boolean} - True if a renderable was restored; false otherwise.
+	 */
+	makeRenderableVisible(renderable_or_id) {
+		const renderable = this._resolveRenderable(renderable_or_id);
+		if (!renderable) return false;
+
+		// If it's already visible, do nothing.
+		if (this._isInProgramCache(renderable)) return true;
+
+		const removed = this._removeRenderableFromHiddenCache(renderable);
+		if (!removed) return false;
+
+		this._addRenderableToProgramCache(renderable);
+		// Notify the renderable (compat listeners) that its visibility changed.
+		try { renderable.notify('visibility', true); } catch (e) { /* ignore */ }
+		return true;
+	}
+
+	/**
+	 * Toggle visibility of a renderable.
+	 * @param {Renderable|string} renderable_or_id
+	 * @param {boolean} should_be_visible
+	 * @returns {boolean}
+	 */
+	setRenderableVisible(renderable_or_id, should_be_visible) {
+		return should_be_visible
+			? this.makeRenderableVisible(renderable_or_id)
+			: this.makeRenderableInvisible(renderable_or_id);
+	}
+
+	/**
+	 * Returns whether a renderable is currently considered visible (i.e., in the draw cache).
+	 * @param {Renderable|string} renderable_or_id
+	 * @returns {boolean}
+	 */
+	isRenderableVisible(renderable_or_id) {
+		const renderable = this._resolveRenderable(renderable_or_id);
+		if (!renderable) return false;
+		return this._isInProgramCache(renderable);
+	}
+
+	/**
+	 * Internal: add a renderable to the visible program cache.
+	 * @param {Renderable} renderable
+	 * @private
+	 */
+	_addRenderableToProgramCache(renderable) {
+		const program_name = renderable.program;
+		if (!this._program_cache.has(program_name))
+			this._program_cache.set(program_name, new Set());
+		this._program_cache.get(program_name).add(renderable);
+	}
+
+	/**
+	 * Internal: remove a renderable from the visible program cache.
+	 * @param {Renderable} renderable
+	 * @returns {boolean} - True if removed from visible cache.
+	 * @private
+	 */
+	_removeRenderableFromProgramCache(renderable) {
+		const program_name = renderable.program;
+		if (!this._program_cache.has(program_name)) return false;
+
+		const cache = this._program_cache.get(program_name);
+		const did_delete = cache.delete(renderable);
+
+		if (cache.size === 0) {
+			this._program_cache.delete(program_name);
+		}
+		return did_delete;
+	}
+
+	/**
+	 * Internal: add a renderable to the hidden cache.
+	 * @param {Renderable} renderable
+	 * @private
+	 */
+	_addRenderableToHiddenCache(renderable) {
+		const program_name = renderable.program;
+		if (!this._hidden_program_cache.has(program_name))
+			this._hidden_program_cache.set(program_name, new Set());
+		this._hidden_program_cache.get(program_name).add(renderable);
+	}
+
+	/**
+	 * Internal: remove a renderable from the hidden cache.
+	 * @param {Renderable} renderable
+	 * @returns {boolean} - True if removed from hidden cache.
+	 * @private
+	 */
+	_removeRenderableFromHiddenCache(renderable) {
+		const program_name = renderable.program;
+		if (!this._hidden_program_cache.has(program_name)) return false;
+
+		const cache = this._hidden_program_cache.get(program_name);
+		const did_delete = cache.delete(renderable);
+
+		if (cache.size === 0) {
+			this._hidden_program_cache.delete(program_name);
+		}
+		return did_delete;
+	}
+
+	/**
+	 * Internal: check if a renderable is in the visible cache.
+	 * @param {Renderable} renderable
+	 * @returns {boolean}
+	 * @private
+	 */
+	_isInProgramCache(renderable) {
+		const program_name = renderable.program;
+		return this._program_cache.has(program_name) &&
+			this._program_cache.get(program_name).has(renderable);
+	}
+
+	/**
+	 * Internal: check if a renderable is in the hidden cache.
+	 * @param {Renderable} renderable
+	 * @returns {boolean}
+	 * @private
+	 */
+	_isInHiddenCache(renderable) {
+		const program_name = renderable.program;
+		return this._hidden_program_cache.has(program_name) &&
+			this._hidden_program_cache.get(program_name).has(renderable);
+	}
+
+	/**
+	 * Internal: resolve a renderable from an instance or an id string.
+	 * Searches both visible and hidden caches.
+	 * @param {Renderable|string} renderable_or_id
+	 * @returns {Renderable|null}
+	 * @private
+	 */
+	_resolveRenderable(renderable_or_id) {
+		if (renderable_or_id instanceof Renderable) return renderable_or_id;
+		const id = String(renderable_or_id);
+		for (let r of this.getAllRenderables()) {
+			if (r.id === id) return r;
+		}
+		return null;
 	}
 
 	_addEventHandler(renderer, parent, child) {

--- a/src/gl/buffer-attribute.js
+++ b/src/gl/buffer-attribute.js
@@ -6,12 +6,20 @@
  */
 
 export default class BufferAttribute {
-
-	constructor(size, type = WebGLRenderingContext.FLOAT, offset = 0, stride = 0) {
+	/**
+	 * Constructs an instance of a BufferAttribute.
+	 * @param {number} size - The number of components per vertex attribute. Must be 1, 2, 3, or 4.
+	 * @param {GLenum} type - The data type of each component in the array.
+	 * @param {number} offset - Offset in bytes of the first component in the vertex attribute array. Must be a multiple of the byte length of type.
+	 * @param {number} stride - The distance in bytes between the beginning of consecutive vertex attributes. Can be 0 to indicate that the attributes are tightly packed.
+	 * @param {number} elementCount - The total number of elements in the attribute. This is crucial for drawing operations.
+	 */
+	constructor(size, type = WebGLRenderingContext.FLOAT, offset = 0, stride = 0, elementCount = 0) {
 		this._size = size;
 		this._type = type;
 		this._offset = offset;
 		this._stride = stride;
+		this._elementCount = elementCount;
 	}
 
 	get size() {
@@ -28,6 +36,14 @@ export default class BufferAttribute {
 
 	get stride() {
 		return this._stride;
+	}
+
+	get elementCount() {
+		return this._elementCount;
+	}
+
+	set elementCount(count) {
+		this._elementCount = count;
 	}
 
 }

--- a/src/gl/geometry/geometry.js
+++ b/src/gl/geometry/geometry.js
@@ -57,6 +57,14 @@ export default class Geometry {
 		return this._vao;
 	}
 
+	/**
+ * Checks if the geometry has been initialized.
+ * @return {Boolean} True if initialized, false otherwise.
+ */
+	get isInitialized() {
+		return this._initialized;
+	}
+
 	addAttribute(name, attribute) {
 		if(this._attributes.has(name))
 			throw new Error(`Attribute ${name} already exists in this geometry.`);

--- a/src/gl/renderable.js
+++ b/src/gl/renderable.js
@@ -67,8 +67,8 @@ export default class Renderable extends Object3D {
 	}
 
 	setShaderState(renderer) {
-		if (this._new_geometry && !this._geometry.isInitialized) {
-			this._geometry.destroy(renderer);
+		if (this._new_geometry) {
+			if (this._geometry.isInitialized) this._geometry.destroy(renderer);
 			this._geometry = this._new_geometry;
 			this._geometry.initialize(renderer);
 			this._new_geometry = null;

--- a/src/gl/renderable.js
+++ b/src/gl/renderable.js
@@ -60,11 +60,14 @@ export default class Renderable extends Object3D {
 
 		this._model_uniform_location = program.getUniform('model');
 
-		this._geometry.initialize(renderer);
+		// Only initialize geometry if it hasn't been initialized yet
+		if (!this._geometry.isInitialized) {
+			this._geometry.initialize(renderer);
+		}
 	}
 
 	setShaderState(renderer) {
-		if (this._new_geometry) {
+		if (this._new_geometry && !this._geometry.isInitialized) {
 			this._geometry.destroy(renderer);
 			this._geometry = this._new_geometry;
 			this._geometry.initialize(renderer);

--- a/src/gl/renderable.js
+++ b/src/gl/renderable.js
@@ -3,11 +3,13 @@
  * Such object has a shader program associated with it and a geometry of some kind
  *
  * @author noodep
- * @version 0.19
+ * @version 0.20
  */
 
 import { dl } from '../util/log.js';
 import Object3D from '../3d/object3d.js';
+
+/** @typedef {import('../gl/geometry/geometry.js')} Geometry */
 
 /**
  * A class to represent an Object3D that can be rendered on a screen (by a
@@ -20,38 +22,59 @@ export default class Renderable extends Object3D {
 	 * @memberOf module:3d
 	 * @alias Renderable
 	 *
-	 * @param {Array} geometry - This object geometry.
+	 * @param {String} id - The unique identifier of this object.
+	 * @param {String} name - The name of this object.
+	 * @param {VecLike} origin - The origin position of this object.
+	 * @param {QuatLike} orientation - The orientation of this object.
+	 * @param {VecLike} scale - The scale of this object.
+	 * @param {Geometry} geometry - This object geometry.
 	 * @param {String} program - The name of this object rendering program.
-	 * @param {Object} options - Object3D options - id, origin, orientation, scale.
 	 * @return {module:3d.Renderable} - The newly created Renderable.
 	 */
 	constructor(id, name, origin, orientation, scale, geometry, program) {
 		super(id, name, origin, orientation, scale);
-		this._geometry = geometry;
-		this._program = program;
-		this._model_uniform_location = undefined;
+		/** @type {Geometry} */ this._geometry = geometry;
+		/** @type {String} */ this._program = program;
+		/** @type {WebGLUniformLocation|undefined} */ this._model_uniform_location = undefined;
 
 		// Place to store a geometry between being set with the setter and being
 		// initialized later in setShaderState().
-		this._new_geometry = null;
+		/** @type {Geometry} */ this._new_geometry = null;
 	}
 
+	/**
+	 * Creates a new Renderable instance.
+	 *
+	 * @param {Object} params - The parameters for the Renderable.
+	 * @param {String} params.id - The unique identifier of this object.
+	 * @param {String} params.name - The name of this object.
+	 * @param {Vec3} params.origin - The origin position of this object.
+	 * @param {Quaternion} params.orientation - The orientation of this object.
+	 * @param {Vec3} params.scale - The scale of this object.
+	 * @param {Geometry} params.geometry - This object geometry.
+	 * @param {String} params.program - The name of this object rendering program.
+	 * @return {module:3d.Renderable} - The newly created Renderable.
+	 */
 	static create({ id, name, origin, orientation, scale, geometry, program } = {}) {
 		return new Renderable(id, name, origin, orientation, scale, geometry, program);
 	}
 
+	/** @returns {string} The name of the object rendering program. */
 	get program() {
 		return this._program;
 	}
 
+	/** @returns {Geometry} The geometry of the object. */
 	get geometry() {
 		return this._geometry;
 	}
 
+	/** @param {Geometry} geometry - The geometry of the object. */
 	set geometry(geometry) {
 		this._new_geometry = geometry;
 	}
 
+	/** @param {WebGLRenderer} renderer - Initialize GPU state for this renderable. */
 	initialize(renderer) {
 		dl(`Initializing Renderable with id ${this.id}.`);
 
@@ -66,6 +89,7 @@ export default class Renderable extends Object3D {
 		}
 	}
 
+	/** @param {WebGLRenderer} renderer - Bind Vertex Array Object and pre-draw uniforms. */
 	setShaderState(renderer) {
 		if (this._new_geometry) {
 			if (this._geometry.isInitialized) this._geometry.destroy(renderer);
@@ -78,10 +102,12 @@ export default class Renderable extends Object3D {
 		renderer._context.uniformMatrix4fv(this._model_uniform_location, false, this.worldModel.matrix);
 	}
 
+	/** @param {WebGLRenderer} renderer - Unbind Vertex Array Object and post-draw cleanup. */
 	cleanShaderState(renderer) {
 		renderer.activateVertexArray(null);
 	}
 
+	/** @param {WebGLRenderer} renderer - Issue draw call for this renderable. */
 	render(renderer) {
 		this._geometry.render(renderer);
 	}

--- a/src/gl/webgl-renderer.js
+++ b/src/gl/webgl-renderer.js
@@ -193,7 +193,7 @@ export default class WebGLRenderer {
 		}
 
 		if(this._active_program == name) {
-			wl('Program already active. Try minimizing program switching.');
+			// wl('Program already active. Try minimizing program switching.'); commented out due to the amount of reused programs.
 			return true;
 		}
 

--- a/src/math/quat.js
+++ b/src/math/quat.js
@@ -303,8 +303,56 @@ export default class Quaternion {
 		return v;
 	}
 
+	/**
+	 * Calculates the dot product of this quaternion with another.
+	 * @param {Quaternion} other - The other quaternion to dot with this one.
+	 * @return {number} The dot product of the two quaternions.
+	 */
+	dot(other) {
+		return this._q[0] * other._q[0] + this._q[1] * other._q[1] + this._q[2] * other._q[2] + this._q[3] * other._q[3];
+	}
+
 	[Symbol.iterator]() {
 		return this._q[Symbol.iterator]();
+	}
+
+	/**
+	 * Negates the quaternion, effectively inverting its direction.
+	 * @return {module:math.Quaternion} - This quaternion, after negation.
+	 */
+	negate() {
+		this._q[0] = -this._q[0];
+		this._q[1] = -this._q[1];
+		this._q[2] = -this._q[2];
+		this._q[3] = -this._q[3];
+		return this;
+	}
+
+	/**
+	 * Adds another quaternion to this quaternion.
+	 * @param {Quaternion} other - The other quaternion to add.
+	 * @return {Quaternion} - This quaternion after addition.
+	 */
+	add(other) {
+		this._q[0] += other._q[0];
+		this._q[1] += other._q[1];
+		this._q[2] += other._q[2];
+		this._q[3] += other._q[3];
+		return this;
+	}
+
+	/**
+	 * Adds another quaternion to this one, scaled by a factor.
+	 * @param {Quaternion} other - The other quaternion to add.
+	 * @param {number} scale - The scale factor.
+	 * @return {Quaternion} - This quaternion after the scaled addition.
+	 */
+	addScaled(other, scale) {
+		this._q[0] += other._q[0] * scale;
+		this._q[1] += other._q[1] * scale;
+		this._q[2] += other._q[2] * scale;
+		this._q[3] += other._q[3] * scale;
+		return this;
 	}
 
 	/**

--- a/src/math/vec3.js
+++ b/src/math/vec3.js
@@ -269,6 +269,11 @@ export default class Vec3 {
 		return this;
 	}
 
+	abs() {
+		this._v[0] = Math.abs(this._v[0]);
+		this._v[1] = Math.abs(this._v[1]);
+		this._v[2] = Math.abs(this._v[2]);
+	}
 	/**
 	 * Subtracts the specified vector from this vector.
 	 *
@@ -467,6 +472,9 @@ export default class Vec3 {
 		return this._v[Symbol.iterator]();
 	}
 
+	isUniform() {
+		return this._v[0] == this._v[1] && this._v[1] == this._v[2];
+	}
 	/**
 	 * Returns a human readable string representing this vector.
 	 *

--- a/src/util/listenable.js
+++ b/src/util/listenable.js
@@ -44,16 +44,22 @@ export default class Listenable {
 	}
 
 	/**
-	 * Removes a specified listener of a specified type.
+	 * Removes a specified listener of a specified type or all listeners of that type if no specific listener is provided.
 	 *
-	 * @param type - The type of listener to remove.
-	 * @param {Function} listener - The listener to remove.
+	 * @param {string} type - The type of listener to remove.
+	 * @param {Function} [listener] - The listener to remove. If not provided, all listeners for the type are removed.
 	 */
 	removeListener(type, listener) {
-		let type_listeners = this._listeners.get(type);
-		if (type_listeners) {
-			if (type_listeners.delete(listener) && type_listeners.size === 0) {
-				this._listeners.delete(type);
+		if (listener === undefined) {
+			// If no listener is provided, remove all listeners for the type
+			this._listeners.delete(type);
+		} else {
+			// If a specific listener is provided, remove only that listener
+			let type_listeners = this._listeners.get(type);
+			if (type_listeners) {
+				if (type_listeners.delete(listener) && type_listeners.size === 0) {
+					this._listeners.delete(type);
+				}
 			}
 		}
 	}

--- a/test/scripts/3d/control/orbit-test.js
+++ b/test/scripts/3d/control/orbit-test.js
@@ -2,12 +2,14 @@
  * @file orbit control tests
  *
  * @author noodep
- * @version 0.82
+ * @version 0.83
  */
 
-import { epsilonEquals } from '../../test-utils.js';
+import { epsilonEquals, approxEquals } from '../../test-utils.js';
 
+import Vec2 from '/src/math/vec2.js'
 import Vec3 from '/src/math/vec3.js';
+import Quat from '/src/math/quat.js'
 import OrbitControl from '/src/3d/control/orbit.js';
 
 export default class OrbitControlTest {
@@ -19,6 +21,9 @@ export default class OrbitControlTest {
 		OrbitControlTest.testDefaultConstruction();
 		OrbitControlTest.offsetSettingCopiesValuesAndDoesNotKeepAReferenceToSuppliedVec3();
 		OrbitControlTest.setOnSphereSetsAzimuthAndInclinationAndOnlyUpdatesPositionOnce();
+		OrbitControlTest.cartesianToSphericalTest();
+		OrbitControlTest.quaternionToAzimuthInclinationTest();
+		OrbitControlTest.setOrbitControlToTargetPoseTest();
 
 		console.timeEnd('Perf');
 		console.log('%c----------------------------------------','color:lightblue;');
@@ -71,5 +76,100 @@ export default class OrbitControlTest {
 			`setOnSphere should update pose only once, but updated pose ${target.update_count} times`
 		);
 	}
+
+		/**
+		 * Tests the cartesianToSpherical function with a complex and a simple case.
+		 */
+		static cartesianToSphericalTest() {
+			// Complex case
+			let offset = new Vec3(0, 0, 0);
+			let position = new Vec3(1, 1, 1);
+			let expected = new Vec3(Math.sqrt(3), Math.atan2(1, 1), Math.acos(1 / Math.sqrt(3)));
+			let actual = OrbitControl.cartesianToSpherical(offset, position);
+			console.assert(actual.equals(expected), `Expected ${actual} to equal ${expected}`);
+
+			// Simple case
+			position = new Vec3(1, 0, 0); // Position on X-axis at distance 1
+			expected = new Vec3(1, 0, Math.PI / 2); // Radius 1, azimuth 0, inclination π/2
+			actual = OrbitControl.cartesianToSpherical(offset, position);
+			console.assert(actual.equals(expected), `Expected ${actual} to equal ${expected}`);
+		}
+
+			/**
+			 * Tests the quaternionToAzimuthInclination function with a complex and a simple case.
+			 */
+		static quaternionToAzimuthInclinationTest() {
+			// Complex case
+			let orientation = new Quat().fromAxisRotation(Math.PI / 4, Vec3.Y_AXIS).multiply(new Quat().fromAxisRotation(Math.PI / 3, Vec3.Z_AXIS));
+			let forward = new Vec3(0, 0, 1);
+			forward = orientation.rotate(forward);
+
+			// Compute expected azimuth and inclination from the rotated vector
+			let expected = new Vec2();
+			expected.x = Math.atan2(forward._v[1], forward._v[0]);
+			expected.y = Math.acos(forward._v[2] / forward.magnitude());
+			expected.y += OrbitControl.HALF_PI;
+
+			let actual = OrbitControl.quaternionToAzimuthInclination(orientation);
+			console.assert(actual.equals(expected), `Expected ${actual} to equal ${expected}`);
+
+			// Simple case
+			orientation = new Quat().fromAxisRotation(Math.PI / 2, new Vec3(0, 0, 1)); // 90 degrees rotation around Z-axis
+			forward = new Vec3(1, 0, 0); // Forward along X-axis
+
+			// Compute expected azimuth and inclination from the rotated vector
+			expected = new Vec2();
+			expected.x = 0; // Along X-axis
+			expected.y = Math.PI / 2; // In XY plane
+
+			actual = OrbitControl.quaternionToAzimuthInclination(orientation);
+			console.assert(actual.equals(expected), `Expected ${actual} to equal ${expected}`);
+		}
+
+			/**
+			 * Tests the setOrbitControlToTargetPose function with a complex and a simple case.
+			 */
+		static setOrbitControlToTargetPoseTest() {
+			// Complex case
+			let target = {
+					position: new Vec3(1, 1, 1),
+					orientation: new Quat().fromAxisRotation(Math.PI / 4, Vec3.Y_AXIS).multiply(new Quat().fromAxisRotation(Math.PI / 3, Vec3.Z_AXIS)),
+					setPose: function() {},
+			};
+			let oc = new OrbitControl(target);
+			oc.setOrbitControlToTargetPose();
+
+			let forward = new Vec3(0, 0, 1);
+			forward = target.orientation.rotate(forward);
+
+			// Compute expected azimuth and inclination from the rotated vector
+			let expected_radius = Math.sqrt(3);
+			let azimuth = Math.atan2(forward._v[1], forward._v[0]);
+			// We need to make sure that the azimuth is within the correct ranges
+			let expected_azimuth = (azimuth + OrbitControl.TWO_PI) % OrbitControl.TWO_PI;
+			let expected_inclination = Math.acos(forward._v[2] / forward.magnitude());
+			expected_inclination += OrbitControl.HALF_PI;
+
+			console.assert(approxEquals(oc.radius, expected_radius), `Expected radius ${oc.radius} to equal ${expected_radius}`);
+			console.assert(approxEquals(oc.azimuth, expected_azimuth), `Expected azimuth ${oc.azimuth} to equal ${expected_azimuth}`);
+			console.assert(approxEquals(oc.inclination, expected_inclination), `Expected inclination ${oc.inclination} to equal ${expected_inclination}`);
+
+			// Simple case
+			target = {
+					position: new Vec3(1, 0, 0), // Set on X-axis at distance 1
+					orientation: new Quat().fromAxisRotation(Math.PI / 2, new Vec3(0, 0, 1)), // Rotate 90 degrees around Z-axis
+					setPose: function() {},
+			};
+			oc = new OrbitControl(target);
+			oc.setOrbitControlToTargetPose();
+
+			expected_radius = 1; // Distance from origin
+			expected_azimuth = 0; // 0 degrees from X-axis in XY-plane
+			expected_inclination = Math.PI / 2; // On XY-plane
+
+			console.assert(approxEquals(oc.radius, expected_radius), `Expected radius ${oc.radius} to equal ${expected_radius}`);
+			console.assert(approxEquals(oc.azimuth, expected_azimuth), `Expected azimuth ${oc.azimuth} to equal ${expected_azimuth}`);
+			console.assert(approxEquals(oc.inclination, expected_inclination), `Expected inclination ${oc.inclination} to equal ${expected_inclination}`);
+		}
 
 }

--- a/test/scripts/test-utils.js
+++ b/test/scripts/test-utils.js
@@ -12,3 +12,6 @@ export function randomFloat32() {
 	return Math.fround(Math.random());
 }
 
+export function approxEquals(a, b, epsilon = 0.00001) {
+	return Math.abs(a - b) < epsilon;
+}


### PR DESCRIPTION
**NOTICE** Must use [observatory#refactor(visibility)-jd-update-visibility-handeling](https://git.ihmc.us/cyber/observatory/observatory/-/merge_requests/197)

# ✨ Refactor: Move Visibility Logic to Scene API

This refactor removes visibility logic from individual renderables and centralizes it inside the **Scene** through a dedicated API.

---

## 🔍 Overview

* ✅ Visibility logic is no longer embedded in renderables.
* ✅ Scene now manages all visibility state via its API.
* ✅ Ensures consistency across animations, hotkeys, and editor interactions.

---

## 🧪 How to Test

1. **Animatable Visibility**

   * Open any scene with visibility animations.
   * ▶️ Play the animation and confirm visibility still works correctly.

2. **Static Visibility (No Animation)**

   * Open a scene without animations.
   * 🔑 Toggle visibility using **hotkeys**, **help scene**, and **scene editor**.
   * Confirm visibility updates as expected.

3. **New Scene Behavior**

   * Open a new scene.
   * ➕ Add new renderables.
   * 👁 Toggle visibility and confirm it reflects correctly.

4. **Animation Editing**

   * Create a new animation, or update visibility on existing keyframes.
   * 🎬 Ensure visibility states are properly animated and reflected.

5. **Visual Representation**

   * All visibility states should display correctly in the UI.
   * Scene Editor visibility button should show:

     * 👁 **Open eye** → Visible
     * 🙈 **Closed eye** → Hidden
     * ◑ **Half-filled circle** → Parent is visible, but some/all children are hidden
